### PR TITLE
fix typo in prep_bm_host.src

### DIFF
--- a/cluster/prep_bm_host.src
+++ b/cluster/prep_bm_host.src
@@ -5,7 +5,7 @@ export PROV_INTF=eno2
 export PROV_BRIDGE=provisioning
 
 export BM_INTF=ens1f0
-export BM_BRIDEG=baremetal
+export BM_BRIDGE=baremetal
 
 export EXT_INTF=eno1
 export PROV_IP_CIDR="172.22.0.0/24"


### PR DESCRIPTION
prep_bm_host.sh failed with checking parameters,
fix BM_BRIDEG to BM_BRIDGE.