### PR TITLE
use ocp minor version for downloading openshift binaries

### DIFF
--- a/prep_bm_host.sh
+++ b/prep_bm_host.sh
@@ -298,7 +298,7 @@ printf "\nInstalling OpenShift binaries...\n\n"
 
     if [[ ! -f "/usr/local/bin/openshift-install" ]]; then
         if [[ "$OPENSHIFT_RHCOS_MAJOR_REL" != "latest" ]]; then
-            curl -O "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_OCP_MINOR_REL/openshift-install-linux-$OPENSHIFT_OCP_MINOR_REL.tar.gz"
+            curl -O "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_OCP_MINOR_REL/openshift-install-linux-$OPENSHIFT_RHCOS_MINOR_REL.tar.gz"
             tar xvf "openshift-install-linux-$OPENSHIFT_OCP_MINOR_REL.tar.gz"
         else
             LATEST_OCP_INSTALLER=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest/ | grep install-linux | cut -d '"' -f 8)
@@ -310,7 +310,7 @@ printf "\nInstalling OpenShift binaries...\n\n"
 
     if [[ ! -f "/usr/local/bin/oc" ]]; then
         if [[ "$OPENSHIFT_RHCOS_MAJOR_REL" != "latest" ]]; then
-            curl -O "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_OCP_MINOR_REL/openshift-client-linux-$OPENSHIFT_OCP_MINOR_REL.tar.gz"
+            curl -O "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_OCP_MINOR_REL/openshift-client-linux-$OPENSHIFT_RHCOS_MINOR_REL.tar.gz"
             tar xvf "openshift-client-linux-$OPENSHIFT_OCP_MINOR_REL.tar.gz"
         else
             LATEST_OCP_CLIENT=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest/ | grep client-linux | cut -d '"' -f 8)


### PR DESCRIPTION
Downloading of openshift installer binaries failed due to
OPENSHIFT_OCP_MINOR_REL not set. This commit sets
the default value of OPENSHIFT_OCP_MINOR_REL to 4.1.0