### PR TITLE
Add support for enrolling 4.2

### DIFF
--- a/kickstart/scripts/enroll_centos_node.sh
+++ b/kickstart/scripts/enroll_centos_node.sh
@@ -2,6 +2,11 @@
 set -eux
 dhclient eno2 || true
 
+# create directories for cri-o before it gets started
+mkdir -p {/var/lib/cni/bin,/etc/kubernetes/cni/net.d,/opt/cni/bin}
+chown root:root /var/lib/cni/bin /etc/kubernetes/cni/net.d /opt/cni/bin
+chmod 755 /var/lib/cni/bin /etc/kubernetes/cni/net.d /opt/cni/bin
+
 # install packages
 yum -y install epel-release
 

--- a/kickstart/scripts/enroll_rhel7_node.sh
+++ b/kickstart/scripts/enroll_rhel7_node.sh
@@ -2,6 +2,11 @@
 set -eux
 dhclient eth1 || true
 
+# create directories for cri-o before it gets started
+mkdir -p {/var/lib/cni/bin,/etc/kubernetes/cni/net.d,/opt/cni/bin}
+chown root:root /var/lib/cni/bin /etc/kubernetes/cni/net.d /opt/cni/bin
+chmod 755 /var/lib/cni/bin /etc/kubernetes/cni/net.d /opt/cni/bin
+
 # enable subscription
 source /etc/profile.env
 subscription-manager register --username $RH_USERNAME --password $RH_PASSWORD --force

--- a/kickstart/scripts/enroll_rhel8_node.sh
+++ b/kickstart/scripts/enroll_rhel8_node.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -eux
+
+# create directories for cri-o before it gets started
+mkdir -p {/var/lib/cni/bin,/etc/kubernetes/cni/net.d,/opt/cni/bin}
+chown root:root /var/lib/cni/bin /etc/kubernetes/cni/net.d /opt/cni/bin
+chmod 755 /var/lib/cni/bin /etc/kubernetes/cni/net.d /opt/cni/bin
+
 # enable subscription
 source /etc/profile.env
 subscription-manager register --username $RH_USERNAME --password $RH_PASSWORD --force

--- a/kickstart/scripts/podman_service.sh
+++ b/kickstart/scripts/podman_service.sh
@@ -2,13 +2,34 @@
 if [ -e /tmp/runonce ]; then
     rm /tmp/runonce
 
-    # run release image
-    CLUSTER_VERSION=$(oc get clusterversion --config=/root/.kube/config --output=jsonpath='{.items[0].status.desired.image}')
-    podman pull --tls-verify=false --authfile /tmp/pull.json $CLUSTER_VERSION
-    RELEASE_IMAGE=$(podman run --rm $CLUSTER_VERSION image machine-config-daemon)
+    # create registries entry
+    echo "unqualified-search-registries = ['registry.access.redhat.com', 'docker.io']" > /etc/containers/registries.conf
+    systemctl restart cri-o
 
-    # run MCD image
-    podman pull --tls-verify=false --authfile /tmp/pull.json $RELEASE_IMAGE
-    podman run -v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --privileged --rm -ti $RELEASE_IMAGE start --node-name $HOSTNAME --once-from /tmp/bootstrap.ign --skip-reboot
+    # check cluster version to apply the right procedure
+    VERSION_NUMBER=$(oc get clusterversion --config=/root/.kube/config  --output=jsonpath='{.items[0].status.desired.version}')
+    if [[ $VERSION_NUMBER == "4.1"* ]]; then	    
+        # run release image
+        CLUSTER_VERSION=$(oc get clusterversion --config=/root/.kube/config --output=jsonpath='{.items[0].status.desired.image}')
+        podman pull --tls-verify=false --authfile /tmp/pull.json $CLUSTER_VERSION
+        RELEASE_IMAGE=$(podman run --rm $CLUSTER_VERSION image machine-config-daemon)
+
+        # run MCD image
+        podman pull --tls-verify=false --authfile /tmp/pull.json $RELEASE_IMAGE
+        podman run -v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --privileged --rm -ti $RELEASE_IMAGE start --node-name $HOSTNAME --once-from /tmp/bootstrap.ign --skip-reboot
+        reboot
+    elif [[ $VERSION_NUMBER == "4.2"* ]]; then
+        # run release image
+	CLUSTER_VERSION=$(oc get clusterversion --config=/root/.kube/config --output=jsonpath='{.items[0].status.desired.image}')
+	RELEASE_IMAGE=$(podman pull --tls-verify=false --authfile /tmp/pull.json $CLUSTER_VERSION)
+	RELEASE_IMAGE_MCD=$(podman run --rm $RELEASE_IMAGE image machine-config-operator)
+
+	# run MCD image
+	MCD_IMAGE=$(podman pull --tls-verify=false --authfile /tmp/pull.json $RELEASE_IMAGE_MCD)
+	podman run -v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --privileged --rm --entrypoint=/usr/bin/machine-config-daemon -ti $MCD_IMAGE start --node-name $HOSTNAME --once-from /tmp/bootstrap.ign --skip-reboot
+    else
+        echo "Openshift version not supported, exiting"
+	exit 1
+    fi
     reboot
 fi


### PR DESCRIPTION
Add common changes that work both on 4.1 and 4.2,
and add a separate workflow to get MCD image on 4.2