### PR TITLE
Prevent error on bootstrap teardown

### DIFF
--- a/terraform/cluster/bootstrap/vm.tf
+++ b/terraform/cluster/bootstrap/vm.tf
@@ -37,7 +37,6 @@ resource "null_resource" "vm_bootstrap_destroy" {
         when = "destroy"
         command = <<EOT
 virsh destroy ${var.cluster_id}-bootstrap
-virsh undefine ${var.cluster_id}-bootstrap
 EOT
     }
 }


### PR DESCRIPTION
We don't actually "define" the bootstrap VM during cluster spin-up, so there is no need to "undefine" during teardown.  This will also prevent us from generating a bogus error.