### PR TITLE
No persist ip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(matchbox_git):
 ## =
 matchbox-data: $(matchbox-data-files)
 
-$(matchbox-data-files): $(manifests) ./scripts/gen_matchbox.sh 
+$(matchbox-data-files): $(manifests) ./scripts/gen_matchbox.sh common.sh
 	./scripts/gen_matchbox.sh data
 
 ## => Baremetal dnsmasq <======================================================

--- a/scripts/gen_terraform.sh
+++ b/scripts/gen_terraform.sh
@@ -139,7 +139,7 @@ gen_terraform_cluster() {
     # Patches
     pxe=$(get_host_var "master-0" pxe) || pxe="bios"
     if ! raw=$(get_asset_raw "$pxe"); then
-        printf "Could not find raw image file in assets!\n"
+        printf "Could not find raw image \"%s\" file in assets!\n" "$pxe"
         exit 1
     fi
 

--- a/scripts/parse_site_config.sh
+++ b/scripts/parse_site_config.sh
@@ -28,7 +28,7 @@ parse_site_config() {
     [[ "$VERBOSE" =~ true ]] && printf "Processing vars in %s\n" "$file"
 
     # shellcheck disable=SC2016
-    if ! values=$(yq 'paths(scalars) as $p | [ ( [ $p[] | tostring ] | join(".") ) , ( getpath($p) | tojson ) ] | join(" ")' "$file"); then
+    if ! values=$(yq 'paths as $p | [ ( [ $p[] | tostring ] | join(".") ) , ( getpath($p) | tojson ) ] | join(" ")' "$file"); then
         printf "Error during parsing...%s\n" "$file"
 
         return 1
@@ -39,6 +39,7 @@ parse_site_config() {
     declare -g -A SITE_CONFIG
     for line in "${lines[@]}"; do
         # create the associative array
+        echo "$line --> ${line%% *} == ${line#* }"
         SITE_CONFIG[${line%% *}]=${line#* }
     done
 }
@@ -86,6 +87,7 @@ map_site_config() {
         if [[ $map_rule =~ ^\| ]]; then
             map_rule=${map_rule#|}
         else
+            echo "$map_rule -- ${SITE_CONFIG[$map_rule]}"
             if [[ -z "${SITE_CONFIG[$map_rule]}" ]]; then
                 printf "Error: %s is unset in %s, must be set\n\n" "$map_rule" "./cluster/site-config.yaml"
                 error=true

--- a/scripts/parse_site_config.sh
+++ b/scripts/parse_site_config.sh
@@ -39,7 +39,6 @@ parse_site_config() {
     declare -g -A SITE_CONFIG
     for line in "${lines[@]}"; do
         # create the associative array
-        echo "$line --> ${line%% *} == ${line#* }"
         SITE_CONFIG[${line%% *}]=${line#* }
     done
 }

--- a/terraform/cluster/masters/matchbox.tf
+++ b/terraform/cluster/masters/matchbox.tf
@@ -13,7 +13,7 @@ resource "matchbox_profile" "master" {
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?mac=${var.master_nodes[count.index]["mac_address"]}",
     (lookup(var.master_nodes[count.index], "provisioning_interface", "") != "" ? "ip=${var.master_nodes[count.index]["provisioning_interface"]}:dhcp" : " "),
     (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" ? "ip=${var.master_nodes[count.index]["baremetal_interface"]}:dhcp" : " "),
-    (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.master_nodes[count.index], "provisioning_interface", "") != "" ? "coreos.no_persist_ip" : " "),
+    (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.master_nodes[count.index], "provisioning_interface", "") != "" ? "coreos.no_persist_ip=1" : " "),
   ])
   raw_ignition = "${var.ignition_config_content}"
 }

--- a/terraform/cluster/masters/matchbox.tf
+++ b/terraform/cluster/masters/matchbox.tf
@@ -13,6 +13,7 @@ resource "matchbox_profile" "master" {
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?mac=${var.master_nodes[count.index]["mac_address"]}",
     (lookup(var.master_nodes[count.index], "provisioning_interface", "") != "" ? "ip=${var.master_nodes[count.index]["provisioning_interface"]}:dhcp" : " "),
     (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" ? "ip=${var.master_nodes[count.index]["baremetal_interface"]}:dhcp" : " "),
+    (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.master_nodes[count.index], "provisioning_interface", "") != "" ? "coreos.no_persist_ip" : " "),
   ])
   raw_ignition = "${var.ignition_config_content}"
 }

--- a/terraform/cluster/masters/matchbox.tf
+++ b/terraform/cluster/masters/matchbox.tf
@@ -11,9 +11,7 @@ resource "matchbox_profile" "master" {
     "${var.pxe_kernel_args}",
     "coreos.inst.install_dev=${var.master_nodes[count.index]["install_dev"]}",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?mac=${var.master_nodes[count.index]["mac_address"]}",
-    (lookup(var.master_nodes[count.index], "provisioning_interface", "") != "" ? "ip=${var.master_nodes[count.index]["provisioning_interface"]}:dhcp" : " "),
-    (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" ? "ip=${var.master_nodes[count.index]["baremetal_interface"]}:dhcp" : " "),
-    (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.master_nodes[count.index], "provisioning_interface", "") != "" ? "coreos.no_persist_ip=1" : " "),
+    (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.master_nodes[count.index], "provisioning_interface", "") != "" ? "ip=dhcp coreos.no_persist_ip=1" : " "),
   ])
   raw_ignition = "${var.ignition_config_content}"
 }

--- a/terraform/workers/main.tf
+++ b/terraform/workers/main.tf
@@ -41,6 +41,7 @@ resource "matchbox_profile" "worker" {
     (var.worker_nodes[count.index]["os_profile"] == "rhcos" ? "coreos.inst=yes coreos.inst.install_dev=${var.worker_nodes[count.index]["install_dev"]} coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?mac=${var.worker_nodes[count.index]["mac_address"]} coreos.inst.image_url=${var.worker_nodes[count.index]["pxe_os_image_url"]}" : "inst.ks=${var.worker_nodes[count.index]["kickstart"]}"),
     (lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "ip=${var.worker_nodes[count.index]["provisioning_interface"]}:dhcp" : " "),
     (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" ? "ip=${var.worker_nodes[count.index]["baremetal_interface"]}:dhcp" : " "),
+    (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" || (lookup(var.master_nodes[count.index], "provisioning_interface", "") != "coreos.no_persist_ip" ? " "),
   ])
 
   raw_ignition= "${file(var.worker_ign_file)}"

--- a/terraform/workers/main.tf
+++ b/terraform/workers/main.tf
@@ -39,9 +39,7 @@ resource "matchbox_profile" "worker" {
   args = flatten([
     "${local.kernel_args}",
     (var.worker_nodes[count.index]["os_profile"] == "rhcos" ? "coreos.inst=yes coreos.inst.install_dev=${var.worker_nodes[count.index]["install_dev"]} coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?mac=${var.worker_nodes[count.index]["mac_address"]} coreos.inst.image_url=${var.worker_nodes[count.index]["pxe_os_image_url"]}" : "inst.ks=${var.worker_nodes[count.index]["kickstart"]}"),
-    (lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "ip=${var.worker_nodes[count.index]["provisioning_interface"]}:dhcp" : " "),
-    (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" ? "ip=${var.worker_nodes[count.index]["baremetal_interface"]}:dhcp" : " "),
-    (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "coreos.no_persist_ip=1" : " "),
+    (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "ip=dhcp coreos.no_persist_ip=1" : " "),
   ])
 
   raw_ignition= "${file(var.worker_ign_file)}"

--- a/terraform/workers/main.tf
+++ b/terraform/workers/main.tf
@@ -41,7 +41,7 @@ resource "matchbox_profile" "worker" {
     (var.worker_nodes[count.index]["os_profile"] == "rhcos" ? "coreos.inst=yes coreos.inst.install_dev=${var.worker_nodes[count.index]["install_dev"]} coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?mac=${var.worker_nodes[count.index]["mac_address"]} coreos.inst.image_url=${var.worker_nodes[count.index]["pxe_os_image_url"]}" : "inst.ks=${var.worker_nodes[count.index]["kickstart"]}"),
     (lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "ip=${var.worker_nodes[count.index]["provisioning_interface"]}:dhcp" : " "),
     (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" ? "ip=${var.worker_nodes[count.index]["baremetal_interface"]}:dhcp" : " "),
-    (lookup(var.master_nodes[count.index], "baremetal_interface", "") != "" || (lookup(var.master_nodes[count.index], "provisioning_interface", "") != "coreos.no_persist_ip" ? " "),
+    (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "coreos.no_persist_ip" : " "),
   ])
 
   raw_ignition= "${file(var.worker_ign_file)}"

--- a/terraform/workers/main.tf
+++ b/terraform/workers/main.tf
@@ -41,7 +41,7 @@ resource "matchbox_profile" "worker" {
     (var.worker_nodes[count.index]["os_profile"] == "rhcos" ? "coreos.inst=yes coreos.inst.install_dev=${var.worker_nodes[count.index]["install_dev"]} coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?mac=${var.worker_nodes[count.index]["mac_address"]} coreos.inst.image_url=${var.worker_nodes[count.index]["pxe_os_image_url"]}" : "inst.ks=${var.worker_nodes[count.index]["kickstart"]}"),
     (lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "ip=${var.worker_nodes[count.index]["provisioning_interface"]}:dhcp" : " "),
     (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" ? "ip=${var.worker_nodes[count.index]["baremetal_interface"]}:dhcp" : " "),
-    (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "coreos.no_persist_ip" : " "),
+    (lookup(var.worker_nodes[count.index], "baremetal_interface", "") != "" || lookup(var.worker_nodes[count.index], "provisioning_interface", "") != "" ? "coreos.no_persist_ip=1" : " "),
   ])
 
   raw_ignition= "${file(var.worker_ign_file)}"


### PR DESCRIPTION
Fix issue with machine config in errored state due to file mismatch.  Dracut has limitations around ip= syntax.  This fix is a workaround for those issues.  Booting is slower.