### PR TITLE
Redfish support

### DIFF
--- a/prep_bm_host.sh
+++ b/prep_bm_host.sh
@@ -74,9 +74,10 @@ if [[ ! -d "/usr/local/bin/python3" ]]; then
         # TODO: use sudo below?
         make
         make install
-        pip3.6 install redfishtool
     ) || exit 1
 fi
+
+pip3.6 install redfishtool
 
 ###------------------------------------------------###
 ### Need interface input from user via environment ###

--- a/prep_bm_host.sh
+++ b/prep_bm_host.sh
@@ -49,13 +49,34 @@ sudo yum install -y $EPEL_PACKAGE
 
 printf "\nInstalling dependencies via yum...\n\n"
 
-sudo yum install -y git podman unzip ipmitool dnsmasq bridge-utils jq nmap libvirt $PIP_PACKAGE
+sudo yum install -y git podman unzip ipmitool dnsmasq bridge-utils jq nmap libvirt openssl-devel zlib-devel $PIP_PACKAGE
 
 ###--------------------###
 ### Install Yq via pip ###
 ###--------------------###
 
 sudo pip install yq
+
+###-----------------------------###
+### Install python3 for redfish ###
+###-----------------------------###
+
+printf "\nInstalling python3 and redfishtool...\n\n"
+
+if [[ ! -d "/usr/local/bin/python3" ]]; then
+    (
+        sudo yum groupinstall -y "Development Tools"
+        cd "$HOME"
+        curl -O https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tar.xz
+        tar -xJf Python-3.6.4.tar.xz
+        cd Python-3.6.4
+        ./configure
+        # TODO: use sudo below?
+        make
+        make install
+        pip3.6 install redfishtool
+    ) || exit 1
+fi
 
 ###------------------------------------------------###
 ### Need interface input from user via environment ###

--- a/terraform/cluster/config.tf
+++ b/terraform/cluster/config.tf
@@ -78,6 +78,12 @@ variable "bootstrap_install_dev" {
   type = "string"
 }
 
+variable "enable_redfish" {
+  description = "If set to true, uses redfish instead of IPMI"
+  type = bool
+  default = false
+}
+
 # ================MATCHBOX=====================
 
 variable "matchbox_rpc_endpoint" {

--- a/terraform/cluster/main.tf
+++ b/terraform/cluster/main.tf
@@ -51,6 +51,7 @@ module "masters" {
 
   cluster_id = "${var.cluster_id}"
 
+  enable_redfish = var.enable_redfish
 }
 
 # ==============BOOTSTRAP=================

--- a/terraform/cluster/masters/ipmi.tf
+++ b/terraform/cluster/masters/ipmi.tf
@@ -1,5 +1,6 @@
 resource "null_resource" "ipmi_master" {
-    count = var.master_count
+    count = var.enable_redfish ? 0 : var.master_count
+
     provisioner "local-exec" {
         command = <<EOT
           ipmitool -I lanplus -H ${var.master_nodes[count.index]["ipmi_host"]} -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe;
@@ -9,7 +10,8 @@ EOT
 }
 
 resource "null_resource" "ipmi_master_cleanup" {
-    count = var.master_count
+    count = var.enable_redfish ? 0 : var.master_count
+
     provisioner "local-exec" {
         when = "destroy"
         command = <<EOT

--- a/terraform/cluster/masters/redfish.tf
+++ b/terraform/cluster/masters/redfish.tf
@@ -1,0 +1,21 @@
+resource "null_resource" "redfish_master" {
+    count = var.enable_redfish ? var.master_count : 0
+
+    provisioner "local-exec" {
+        command = <<EOT
+          redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems setBootOverride Once Pxe || true
+          redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems reset GracefulRestart || redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems reset On || true
+EOT
+    }
+}
+
+resource "null_resource" "redfish_master_cleanup" {
+    count = var.enable_redfish ? var.master_count : 0
+
+    provisioner "local-exec" {
+        when = "destroy"
+        command = <<EOT
+          redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems reset ForceOff || true
+EOT
+    }
+}

--- a/terraform/cluster/masters/redfish.tf
+++ b/terraform/cluster/masters/redfish.tf
@@ -4,7 +4,7 @@ resource "null_resource" "redfish_master" {
     provisioner "local-exec" {
         command = <<EOT
           redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems setBootOverride Once Pxe || true
-          redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems reset GracefulRestart || redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems reset On || true
+          redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems reset On || redfishtool -r ${var.master_nodes[count.index]["ipmi_host"]} -u ${var.master_nodes[count.index]["ipmi_user"]} -p ${var.master_nodes[count.index]["ipmi_pass"]} Systems reset GracefulRestart || true
 EOT
     }
 }

--- a/terraform/cluster/masters/variables.tf
+++ b/terraform/cluster/masters/variables.tf
@@ -30,3 +30,9 @@ variable "ignition_config_content" {
 variable "master_nodes" {
   type = list(map(string))
 }
+
+variable "enable_redfish" {
+  description = "If set to true, uses redfish instead of IPMI"
+  type = bool
+  default = false
+}

--- a/terraform/workers/config.tf
+++ b/terraform/workers/config.tf
@@ -13,6 +13,12 @@ variable "nameserver" {
   default = ""
 }
 
+variable "enable_redfish" {
+  description = "If set to true, uses redfish instead of IPMI"
+  type = bool
+  default = false
+}
+
 # ================MATCHBOX=====================
 
 variable "matchbox_rpc_endpoint" {

--- a/terraform/workers/ipmi.tf
+++ b/terraform/workers/ipmi.tf
@@ -1,10 +1,10 @@
 resource "null_resource" "ipmi_worker" {
     count = var.enable_redfish ? 0 : var.worker_count
-    
+
     provisioner "local-exec" {
         command = <<EOT
-          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe;
-          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power cycle || ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power on;
+          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe || true;
+          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power cycle || ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power on || true;
 EOT
     }
 }
@@ -15,7 +15,7 @@ resource "null_resource" "ipmi_worker_clenup" {
     provisioner "local-exec" {
         when = "destroy"
         command = <<EOT
-          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power off;
+          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power off || true;
 EOT
     }
 }

--- a/terraform/workers/ipmi.tf
+++ b/terraform/workers/ipmi.tf
@@ -1,5 +1,6 @@
 resource "null_resource" "ipmi_worker" {
-    count = var.worker_count
+    count = var.enable_redfish ? 0 : var.worker_count
+    
     provisioner "local-exec" {
         command = <<EOT
           ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe;
@@ -9,7 +10,8 @@ EOT
 }
 
 resource "null_resource" "ipmi_worker_clenup" {
-    count = var.worker_count
+    count = var.enable_redfish ? 0 : var.worker_count
+
     provisioner "local-exec" {
         when = "destroy"
         command = <<EOT

--- a/terraform/workers/ipmi.tf
+++ b/terraform/workers/ipmi.tf
@@ -1,10 +1,10 @@
 resource "null_resource" "ipmi_worker" {
     count = var.enable_redfish ? 0 : var.worker_count
-
+    
     provisioner "local-exec" {
         command = <<EOT
-          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe || true;
-          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power cycle || ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power on || true;
+          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe;
+          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power cycle || ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power on;
 EOT
     }
 }
@@ -15,7 +15,7 @@ resource "null_resource" "ipmi_worker_clenup" {
     provisioner "local-exec" {
         when = "destroy"
         command = <<EOT
-          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power off || true;
+          ipmitool -I lanplus -H ${var.worker_nodes[count.index]["ipmi_host"]} -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power off;
 EOT
     }
 }

--- a/terraform/workers/redfish.tf
+++ b/terraform/workers/redfish.tf
@@ -1,0 +1,21 @@
+resource "null_resource" "redfish_worker" {
+    count = var.enable_redfish ? var.worker_count : 0
+
+    provisioner "local-exec" {
+        command = <<EOT
+          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems setBootOverride Once Pxe
+          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset GracefulRestart || redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset On
+EOT
+    }
+}
+
+resource "null_resource" "redfish_worker_clenup" {
+    count = var.enable_redfish ? var.worker_count : 0
+
+    provisioner "local-exec" {
+        when = "destroy"
+        command = <<EOT
+          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset ForceOff
+EOT
+    }
+}

--- a/terraform/workers/redfish.tf
+++ b/terraform/workers/redfish.tf
@@ -3,8 +3,8 @@ resource "null_resource" "redfish_worker" {
 
     provisioner "local-exec" {
         command = <<EOT
-          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems setBootOverride Once Pxe
-          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset GracefulRestart || redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset On
+          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems setBootOverride Once Pxe || true
+          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset GracefulRestart || redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset On || true
 EOT
     }
 }
@@ -15,7 +15,7 @@ resource "null_resource" "redfish_worker_clenup" {
     provisioner "local-exec" {
         when = "destroy"
         command = <<EOT
-          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset ForceOff
+          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset ForceOff || true
 EOT
     }
 }

--- a/terraform/workers/redfish.tf
+++ b/terraform/workers/redfish.tf
@@ -4,7 +4,7 @@ resource "null_resource" "redfish_worker" {
     provisioner "local-exec" {
         command = <<EOT
           redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems setBootOverride Once Pxe || true
-          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset GracefulRestart || redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset On || true
+          redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset On || redfishtool -r ${var.worker_nodes[count.index]["ipmi_host"]} -u ${var.worker_nodes[count.index]["ipmi_user"]} -p ${var.worker_nodes[count.index]["ipmi_pass"]} Systems reset GracefulRestart || true
 EOT
     }
 }


### PR DESCRIPTION
Net effect is that it currently is not used unless you manually edit `terraform.tfvars` and add `enable_redfish = true`.  In other words, nothing should change in the existing IPMI-based experience.