### PR TITLE
Enable persistent journal storage

### DIFF
--- a/kickstart/scripts/podman_service.sh
+++ b/kickstart/scripts/podman_service.sh
@@ -31,5 +31,10 @@ if [ -e /opt/runonce ]; then
         echo "Openshift version not supported, exiting"
 	exit 1
     fi
+
+    # fix for machine-config: enable persistent storage for journal
+    mkdir -p /var/log/journal || true
+    sed -i 's/#Storage=auto/Storage=persistent/' /etc/systemd/journald.conf
+
     reboot
 fi


### PR DESCRIPTION
This is needed for machine config to work
as it relies on persistent storage for journal