### PR TITLE
Make port optional in install-config IPMI host address

### DIFF
--- a/terraform/cluster/masters/ipmi.tf
+++ b/terraform/cluster/masters/ipmi.tf
@@ -2,8 +2,8 @@ resource "null_resource" "ipmi_master" {
     count = var.master_count
     provisioner "local-exec" {
         command = <<EOT
-          ipmitool -I lanplus -H ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)!=""}-p ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe;
-          ipmitool -I lanplus -H ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)!=""}-p ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} power cycle || ipmitool -I lanplus -H ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)!=""}-p ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} power on;
+          ipmitool -I lanplus -H ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)!=var.master_nodes[count.index]["ipmi_host"]}-p ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe;
+          ipmitool -I lanplus -H ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)!=var.master_nodes[count.index]["ipmi_host"]}-p ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} power cycle || ipmitool -I lanplus -H ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)!=var.master_nodes[count.index]["ipmi_host"]}-p ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} power on;
 EOT
     }
 }
@@ -13,7 +13,7 @@ resource "null_resource" "ipmi_master_cleanup" {
     provisioner "local-exec" {
         when = "destroy"
         command = <<EOT
-          ipmitool -I lanplus -H ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)!=""}-p ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} power off;
+          ipmitool -I lanplus -H ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)!=var.master_nodes[count.index]["ipmi_host"]}-p ${element(split(":", var.master_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.master_nodes[count.index]["ipmi_user"]} -P ${var.master_nodes[count.index]["ipmi_pass"]} power off;
 EOT
     }
 }

--- a/terraform/workers/ipmi.tf
+++ b/terraform/workers/ipmi.tf
@@ -2,8 +2,8 @@ resource "null_resource" "ipmi_worker" {
     count = var.worker_count
     provisioner "local-exec" {
         command = <<EOT
-          ipmitool -I lanplus -H ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)!=""}-p ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe;
-          ipmitool -I lanplus -H ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)!=""}-p ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power cycle || ipmitool -I lanplus -H ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)!=""}-p ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power on;
+          ipmitool -I lanplus -H ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)!=var.worker_nodes[count.index]["ipmi_host"]}-p ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} chassis bootdev pxe;
+          ipmitool -I lanplus -H ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)!=var.worker_nodes[count.index]["ipmi_host"]}-p ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power cycle || ipmitool -I lanplus -H ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)!=var.worker_nodes[count.index]["ipmi_host"]}-p ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power on;
 EOT
     }
 }
@@ -13,7 +13,7 @@ resource "null_resource" "ipmi_worker_clenup" {
     provisioner "local-exec" {
         when = "destroy"
         command = <<EOT
-          ipmitool -I lanplus -H ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)!=""}-p ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power off;
+          ipmitool -I lanplus -H ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),0)} %{if element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)!=var.worker_nodes[count.index]["ipmi_host"]}-p ${element(split(":", var.worker_nodes[count.index]["ipmi_host"]),1)}%{ endif } -U ${var.worker_nodes[count.index]["ipmi_user"]} -P ${var.worker_nodes[count.index]["ipmi_pass"]} power off;
 EOT
     }
 }


### PR DESCRIPTION
The `split` function in Terraform actually doesn't return an empty-string if the split character is not found in the target string.  Rather, it returns the target string itself.  Fixing this so users don't have to provide IPMI port in host address in install-config.yaml.