### PR TITLE
Filter images_and_binaries by version

### DIFF
--- a/images_and_binaries.sh
+++ b/images_and_binaries.sh
@@ -22,8 +22,8 @@ if [ "$OPENSHIFT_RHCOS_REL" == "GA" ]; then
 
     SHA256=$(curl -sS "$RHCOS_IMAGES_BASE_URI"sha256sum.txt)
 
-    RHCOS_BOOT_IMAGES["ramdisk"]="$(echo "$SHA256" | grep installer-initramfs | rev | cut -d ' ' -f 1 | rev)"
-    RHCOS_BOOT_IMAGES["kernel"]="$(echo "$SHA256" | grep installer-kernel | rev | cut -d ' ' -f 1 | rev)"
+    RHCOS_BOOT_IMAGES["ramdisk"]="$(echo "$SHA256" | grep $OPENSHIFT_RHCOS_MAJOR_REL | grep installer-initramfs | rev | cut -d ' ' -f 1 | rev)"
+    RHCOS_BOOT_IMAGES["kernel"]="$(echo "$SHA256" | grep $OPENSHIFT_RHCOS_MAJOR_REL | grep installer-kernel | rev | cut -d ' ' -f 1 | rev)"
 
     # Now handle metal images and map file names to sha256 values
     FILENAME_LIST=("${RHCOS_BOOT_IMAGES["kernel"]}" "${RHCOS_BOOT_IMAGES["ramdisk"]}")
@@ -40,7 +40,7 @@ if [ "$OPENSHIFT_RHCOS_REL" == "GA" ]; then
         RHCOS_METAL_IMAGES["uefi"]="$UEFI_METAL"
     else
         # 4.3+ uses one unified metal image 
-        UNIFIED_METAL="$(echo "$SHA256" | grep x86_64-metal | rev | cut -d ' ' -f 1 | rev)"
+        UNIFIED_METAL="$(echo "$SHA256" | grep $OPENSHIFT_RHCOS_MAJOR_REL | grep x86_64-metal | rev | cut -d ' ' -f 1 | rev)"
         
         FILENAME_LIST+=("$UNIFIED_METAL")
         


### PR DESCRIPTION
Starting with 4.5.6, the OpenShift mirror began including image files
with and without version numbers in the sha256sum listings*.  This
caused two matches to occur in the images_and_binaries script, producing
data that could not be processed correctly by further scripts such
as gen_matchbox.

To correct this, filter the filenames by version number so that new
and old sha256sum files produce the same behavior.

* See these files for examples:
  https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.5/4.5.6/sha256sum.txt
  https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.5/4.5.2/sha256sum.txt

Signed-off-by: James E. Blair <jeblair@redhat.com>